### PR TITLE
Add Async Tableau Server Job Execution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -127,7 +127,7 @@ statsd==3.3.0
 strict-rfc3339==0.7
 swagger-ui-bundle==0.0.8
 tableaudocumentapi==0.6
-tableauserverclient==0.14.1
+tableauserverclient==0.17.0
 tabulate==0.8.7
 tenacity==6.2.0
 termcolor==1.1.0


### PR DESCRIPTION
### Goal
Allow for Airflow python tasks that wait for the Tableau Server job the kick off to return status before completing.

### Changes Summary
1. Bump `tableauserverclient` python library to v0.17.0 to get more recent `job.wait_for_job()` - c2bad36a9fd8bed0d0b42870aac79446d94928c6
2. Add optional parameter for `refresh_tableau_extract()` to `use_async` - 3750084e20002a7d1cc7236e0f064a72732f6c84
3. Change `tableauserverclient` `connection` handling to use `with` statement instead of explicit close for cleaner code and consistency with other uses - 3750084e20002a7d1cc7236e0f064a72732f6c84